### PR TITLE
Update openhtmltopdf dependencies to 1.0.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject clj-htmltopdf "0.1-alpha7"
+(defproject clj-htmltopdf "0.1-alpha8"
   :description  "Simple Clojure wrapper for Open HTML to PDF"
   :url          "https://github.com/gered/clj-htmltopdf"
   :license      {:name "GNU Lesser General Public License v3.0"
                  :url  "https://www.gnu.org/licenses/lgpl.html"}
 
-  :dependencies [[com.openhtmltopdf/openhtmltopdf-core "1.0.0"]
-                 [com.openhtmltopdf/openhtmltopdf-pdfbox "1.0.0"]
-                 [com.openhtmltopdf/openhtmltopdf-rtl-support "1.0.0"]
-                 [com.openhtmltopdf/openhtmltopdf-svg-support "1.0.0"]
+  :dependencies [[com.openhtmltopdf/openhtmltopdf-core "1.0.4"]
+                 [com.openhtmltopdf/openhtmltopdf-pdfbox "1.0.4"]
+                 [com.openhtmltopdf/openhtmltopdf-rtl-support "1.0.4"]
+                 [com.openhtmltopdf/openhtmltopdf-svg-support "1.0.4"]
                  [org.jsoup/jsoup "1.12.1"]
                  [commons-io/commons-io "2.6"]
                  [hiccup "1.0.5"]]


### PR DESCRIPTION
There are a lot of bug fixes when upgrading from `1.0.0` to `1.0.4` that would be beneficial to have.