### PR TITLE
Update openhtmltopdf version & repository

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject clj-htmltopdf "0.2.1"
+(defproject clj-htmltopdf "0.2.2"
   :description    "Simple Clojure wrapper for Open HTML to PDF"
   :url            "https://github.com/gered/clj-htmltopdf"
   :license        {:name "GNU Lesser General Public License v3.0"
                    :url  "https://www.gnu.org/licenses/lgpl.html"}
 
-  :dependencies   [[com.openhtmltopdf/openhtmltopdf-core "1.0.10"]
-                   [com.openhtmltopdf/openhtmltopdf-pdfbox "1.0.10"]
-                   [com.openhtmltopdf/openhtmltopdf-rtl-support "1.0.10"]
-                   [com.openhtmltopdf/openhtmltopdf-svg-support "1.0.10"]
+  :dependencies   [[io.github.openhtmltopdf/openhtmltopdf-core "1.1.22"]
+                   [io.github.openhtmltopdf/openhtmltopdf-pdfbox "1.1.22"]
+                   [io.github.openhtmltopdf/openhtmltopdf-rtl-support "1.1.22"]
+                   [io.github.openhtmltopdf/openhtmltopdf-svg-support "1.1.22"]
                    [org.jsoup/jsoup "1.15.3"]
                    [commons-io/commons-io "2.11.0"]
                    [hiccup "1.0.5"]]

--- a/src/clj_htmltopdf/watermark.clj
+++ b/src/clj_htmltopdf/watermark.clj
@@ -3,8 +3,9 @@
     [clojure.java.io :as io])
   (:import
     [java.io InputStream OutputStream]
+    [org.apache.pdfbox Loader]
     [org.apache.pdfbox.pdmodel PDDocument PDPage PDPageContentStream PDPageContentStream$AppendMode]
-    [org.apache.pdfbox.pdmodel.font PDType1Font PDFont]
+    [org.apache.pdfbox.pdmodel.font PDType1Font PDFont Standard14Fonts$FontName]
     [org.apache.pdfbox.pdmodel.graphics.image PDImageXObject]
     [org.apache.pdfbox.pdmodel.graphics.state PDExtendedGraphicsState]
     [org.apache.pdfbox.util Matrix]))
@@ -31,23 +32,23 @@
 ;       until something more comprehensive can be implemented such as allowing loading of external
 ;       TTF fonts via PDTrueTypeFont.loadTTF()
 (def watermark-fonts
-  {"times-roman"           PDType1Font/TIMES_ROMAN
-   "times-bold"            PDType1Font/TIMES_BOLD
-   "times-italic"          PDType1Font/TIMES_ITALIC
-   "times-bolditalic"      PDType1Font/TIMES_BOLD_ITALIC
-   "helvetica"             PDType1Font/HELVETICA
-   "helvetica-bold"        PDType1Font/HELVETICA_BOLD
-   "helvetica-oblique"     PDType1Font/HELVETICA_OBLIQUE
-   "helvetica-boldoblique" PDType1Font/HELVETICA_BOLD_OBLIQUE
-   "courier"               PDType1Font/COURIER
-   "courier-bold"          PDType1Font/COURIER_BOLD
-   "courier-oblique"       PDType1Font/COURIER_OBLIQUE
-   "courier-boldoblique"   PDType1Font/COURIER_BOLD_OBLIQUE})
+  {"times-roman"           Standard14Fonts$FontName/TIMES_ROMAN
+   "times-bold"            Standard14Fonts$FontName/TIMES_BOLD
+   "times-italic"          Standard14Fonts$FontName/TIMES_ITALIC
+   "times-bolditalic"      Standard14Fonts$FontName/TIMES_BOLD_ITALIC
+   "helvetica"             Standard14Fonts$FontName/HELVETICA
+   "helvetica-bold"        Standard14Fonts$FontName/HELVETICA_BOLD
+   "helvetica-oblique"     Standard14Fonts$FontName/HELVETICA_OBLIQUE
+   "helvetica-boldoblique" Standard14Fonts$FontName/HELVETICA_BOLD_OBLIQUE
+   "courier"               Standard14Fonts$FontName/COURIER
+   "courier-bold"          Standard14Fonts$FontName/COURIER_BOLD
+   "courier-oblique"       Standard14Fonts$FontName/COURIER_OBLIQUE
+   "courier-boldoblique"   Standard14Fonts$FontName/COURIER_BOLD_OBLIQUE})
 
 (defn render-text-watermark!
   [^PDDocument doc ^PDPage page ^PDPageContentStream cs options]
-  (let [font        (or (get watermark-fonts (:font options))
-                        (get watermark-fonts "helvetica-bold"))
+  (let [font        (PDType1Font. (or (get watermark-fonts (:font options))
+                                      (get watermark-fonts "helvetica-bold")))
         font-size   (float (or (:font-size options) 36.0))
         font-color  (or (:color options) [0 0 0])
         text        (:text options)
@@ -106,7 +107,7 @@
 
 (defn write-watermark!
   [^InputStream pdf ^OutputStream out {:keys [watermark] :as options}]
-  (with-open [doc (PDDocument/load pdf)]
+  (with-open [doc (Loader/loadPDF pdf)]
     (binding [*pdf-images* (atom {})]
       (doseq [^PDPage page (.getPages doc)]
         (let [cs (PDPageContentStream. doc page PDPageContentStream$AppendMode/APPEND true true)]


### PR DESCRIPTION
Use forked & updated [openhtmltopdf project](https://github.com/openhtmltopdf/openhtmltopdf)
Minor changes to use PDFBox 3.x
